### PR TITLE
Navigation helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,39 @@ Outputs contents if at least one of a number of things is truthy *Note that hand
 ### slice
 Loop through a subset of items
 - `{{#slice items limit="2" offset="4"}} some content {{/slice}}
+
+### Block Helpers
+
+### Navigation
+Run the block contents over each item in the navigation
+
+```mustache
+<ul>
+    {{#navigation}}
+        <li>
+            <a href="{{href}}">{{name}}</a>
+            <ul>
+                {{#each children}}
+                    <li>
+                        <a href="{{href}}">{{name}}</a>
+                    </li>
+                {{/each}}
+            </ul>
+        </li>
+    {{/navigation}}
+</ul>
+```
+
+### Sub Navigation
+Run the block contents the children of the matched navigation
+
+```mustache
+<h1>UK</h1>
+<ul>
+    {{#subNavigation '/stream/sections/uk'}}
+        <li>
+            <a href="{{href}}">{{name}}</a>
+        </li>
+    {{/subNavigation}}
+</ul>
+```

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "release": "npm-prepublish --verbose && npm publish && git checkout package.json"
   },
   "dependencies": {
+    "array.prototype.find": "^1.0.0",
     "dateformat": "^1.0.11",
     "es6-promise": "^2.0.1",
     "express-handlebars": "^1.2.1",

--- a/src/extend-helpers.js
+++ b/src/extend-helpers.js
@@ -17,6 +17,8 @@ module.exports = function (helpers) {
 	helpers.slice = require('./helpers/slice');
 	helpers.json = require('./helpers/json');
 	helpers.usePartial = require('./helpers/use-partial');
+	helpers.navigation = require('./helpers/navigation');
+	helpers.subNavigation = require('./helpers/sub-navigation');
 
 	return helpers;
 };

--- a/src/helpers/navigation.js
+++ b/src/helpers/navigation.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = function (params) {
+	// expect the navigation middleware to be used
+	var nav = params.data.root.nav;
+	if (nav) {
+		var buffer = [];
+		nav.forEach(function (sectionItem) {
+			buffer.push(params.fn(sectionItem));
+		});
+		return buffer.join('');
+	} else {
+		return params.inverse();
+	}
+};

--- a/src/helpers/sub-navigation.js
+++ b/src/helpers/sub-navigation.js
@@ -1,0 +1,20 @@
+'use strict';
+
+require('array.prototype.find');
+
+module.exports = function (section, params) {
+    // expect the navigation middleware to be used
+    var nav = params.data.root.nav || [];
+    var sectionItem = nav.find(function (navItem) {
+        return navItem.name === section;
+    });
+    if (sectionItem) {
+        var buffer = [];
+        sectionItem.children.forEach(function (subSectionItem) {
+            buffer.push(params.fn(subSectionItem));
+        });
+        return buffer.join('');
+    } else {
+        return params.inverse();
+    }
+};

--- a/src/helpers/sub-navigation.js
+++ b/src/helpers/sub-navigation.js
@@ -2,11 +2,11 @@
 
 require('array.prototype.find');
 
-module.exports = function (section, params) {
+module.exports = function (sectionHref, params) {
     // expect the navigation middleware to be used
     var nav = params.data.root.nav || [];
     var sectionItem = nav.find(function (navItem) {
-        return navItem.name === section;
+        return navItem.href === sectionHref;
     });
     if (sectionItem) {
         var buffer = [];


### PR DESCRIPTION
Block helpers to iterate over navigation and a particular sub-navigation 

Ideally these helpers would live in [next-navigation](github.com/Financial-Times/next-navigation), but don't think we can append helpers after the helpers have already been set... @wheresrhys?
