### PR TITLE
Faster partial loading

### DIFF
--- a/express.js
+++ b/express.js
@@ -3,6 +3,7 @@
 
 require('es6-promise').polyfill();
 
+var Path = require('path');
 var expressHandlebars = require('express-handlebars');
 var handlebars = require('./handlebars');
 var extendHelpers = require('./src/extend-helpers');
@@ -28,7 +29,7 @@ var nextifyHandlebars = function (options) {
 	});
 
 	var partialsDir = (options.partialsDir || []);
-	var dependencyRoot = options.directory + '/bower_components/';
+	var dependencyRoot = Path.join(options.directory, '/bower_components/');
 	var ignoreListInLinkedDeps = ['.git', 'node_modules', 'bower_components', 'demos'];
 
 	// look up templates on our own to avoid scanning thousands of files

--- a/express.js
+++ b/express.js
@@ -7,9 +7,98 @@ var expressHandlebars = require('express-handlebars');
 var handlebars = require('./handlebars');
 var extendHelpers = require('./src/extend-helpers');
 
+var fs = require('fs');
+var Path = require('path');
+
+var readdirAsync = function(path) {
+	return new Promise(function(res, rej) {
+		fs.readdir(path, function(err, files) {
+			if(err) return rej(err);
+
+			res(files);
+		});
+	});
+};
+
+var lstatAsync = function(path) {
+	return new Promise(function(res, rej) {
+		fs.lstat(path, function(err, stats) {
+			if(err) return rej(err);
+
+			res(stats);
+		});
+	});
+};
+
+var realpathAsync = function(path) {
+	return new Promise(function(res, rej) {
+		fs.realpath(path, function(err, path) {
+			if(err) return rej(err);
+
+			res(path);
+		});
+	});
+};
+
+var dependencyPartialsPaths = function(bower_components, ignores) {
+	console.log("Scanning bower components in ", bower_components, "for partials");
+
+	return readdirAsync(bower_components)
+	.then(function(files) {
+		var stats = files.map(function(path) {
+			var fullPath = Path.join(bower_components, path);
+
+			return lstatAsync(fullPath)
+			.then(function(stat) {
+				return [fullPath, stat.isSymbolicLink()];
+			});
+		});
+
+		return Promise.all(stats)
+		.then(function(stats) {
+			var links = stats
+				.filter(function(it) { return it[1]; })
+				.map(function(it) { return it[0] });
+			var directories = stats
+				.filter(function(it) { return !it[1]; })
+				.map(function(it) { return it[0] });
+
+			console.log("Found components", directories);
+			console.log("Found linked components", links);
+
+			return Promise.all(links.map(function(link) {
+				return realpathAsync(link)
+				.then(function(realPath) {
+					return readdirAsync(realPath)
+					.then(function(items) {
+						return Promise.all(items
+						.filter(function(it) { return ignores.indexOf(it) < 0; })
+						.map(function(it) { return Path.join(realPath, it); })
+						.map(function(path) {
+							return lstatAsync(path)
+							.then(function(stat) { return [path, stat.isDirectory()]; });
+						}))
+					});
+				})
+			}))
+			.then(function(paths) {
+				return paths.reduce(function(acc, it) { return acc.concat(it); }, []);
+			})
+			.then(function(paths) {
+				return paths
+				.filter(function(it) { return it[1]; })
+				.map(function(it) { return it[0]; })
+			})
+			.then(function(paths) {
+				return directories.concat(paths);
+			});
+		});
+	});
+};
+
 var nextifyHandlebars = function (options) {
 	if (!options || !options.directory) {
-		throw 'next-handlebars requires an options object containing a directory property'
+		throw 'next-handlebars requires an options object containing a directory property';
 	}
 	var configuredHandlebars = handlebars({
 		helpers: options.helpers
@@ -17,24 +106,28 @@ var nextifyHandlebars = function (options) {
 
 	var helpers = extendHelpers(options.helpers);
 
-	var expressHandlebarsInstance = new expressHandlebars.create({
-		// use a handlebars instance we have direct access to so we can expose partials
-		handlebars: configuredHandlebars,
-		extname: '.html',
-		helpers: helpers,
-		defaultLayout: options.defaultLayout || false,
-		layoutsDir: options.layoutsDir || undefined,
-		partialsDir: [
-			options.directory + '/bower_components'
-		].concat(options.partialsDir || [])
-	});
+	return dependencyPartialsPaths(options.directory + '/bower_components', ['.git', 'node_modules', 'bower_components'])
+	.then(function(partials) {
+		var partialsDir = (options.partialsDir || [])
+			.concat(partials);
 
-	// makes the usePartial helper possible
-	return expressHandlebarsInstance.getPartials().then(function(partials) {
-		configuredHandlebars.partials = partials;
-		return expressHandlebarsInstance;
-	});
+		console.log("Creating expressHandlebarsInstance with partialsDir", partialsDir);
+		var expressHandlebarsInstance = new expressHandlebars.create({
+			// use a handlebars instance we have direct access to so we can expose partials
+			handlebars: configuredHandlebars,
+			extname: '.html',
+			helpers: helpers,
+			defaultLayout: options.defaultLayout || false,
+			layoutsDir: options.layoutsDir || undefined,
+			partialsDir: partialsDir
+		});
 
+		// makes the usePartial helper possible
+		return expressHandlebarsInstance.getPartials().then(function(partials) {
+			configuredHandlebars.partials = partials;
+			return expressHandlebarsInstance;
+		});
+	});
 };
 
 var applyToExpress = function (app, options) {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "dateformat": "^1.0.11",
+    "denodeify": "^1.2.1",
     "es6-promise": "^2.0.1",
     "express-handlebars": "^2.0.0",
     "handlebars": "^3.0.0"

--- a/src/load-partials.js
+++ b/src/load-partials.js
@@ -9,73 +9,73 @@ var lstatAsync = denodeify(fs.lstat);
 var realpathAsync = denodeify(fs.realpath);
 
 var flatten = function(list) {
-  return list.reduce(function(acc, it) {
-    return acc.concat(it);
-  }, []);
+	return list.reduce(function(acc, it) {
+		return acc.concat(it);
+	}, []);
 };
 
 var itemsWithStats = function(directory) {
-  return readdirAsync(directory)
-  .then(function(files) {
-    var stats = files.map(function(file) {
-      var fullPath = Path.join(directory, file);
+	return readdirAsync(directory)
+	.then(function(files) {
+		var stats = files.map(function(file) {
+			var fullPath = Path.join(directory, file);
 
-      return lstatAsync(fullPath)
-      .then(function(stat) {
-        return {name: file, path: fullPath, stat: stat};
-      });
-    });
+			return lstatAsync(fullPath)
+			.then(function(stat) {
+				return {name: file, path: fullPath, stat: stat};
+			});
+		});
 
-    return Promise.all(stats);
-  });
+		return Promise.all(stats);
+	});
 };
 
 var classifyItems = function(items, otherPaths) {
-  return ({
-    directories: items
-      .filter(function(it) { return it.stat.isDirectory(); })
-      .concat(otherPaths)
-      .map(function(it) { return { name: it.path || it, path: it.path || it }; }),
+	return ({
+		directories: items
+			.filter(function(it) { return it.stat.isDirectory(); })
+			.concat(otherPaths)
+			.map(function(it) { return { name: it.path || it, path: it.path || it }; }),
 
-  links: items
-    .filter(function(it) { return it.stat.isSymbolicLink(); })
-    .map(function(it) { return it.path })
-  });
+	links: items
+		.filter(function(it) { return it.stat.isSymbolicLink(); })
+		.map(function(it) { return it.path })
+	});
 };
 
 var selectValidLinkedPaths = function(linkedItems, ignores, linkPath) {
-  return linkedItems
-    .filter(function(item) { return ignores.indexOf(item.name) < 0 && item.stat.isDirectory(); })
-    .map(function(item) { return { name: Path.join(linkPath, item.name), path: item.path }; });
+	return linkedItems
+		.filter(function(item) { return ignores.indexOf(item.name) < 0 && item.stat.isDirectory(); })
+		.map(function(item) { return { name: Path.join(linkPath, item.name), path: item.path }; });
 };
 
 var itemNamespace = function(name, bowerRoot) {
-  var namespace = name.replace(bowerRoot, '');
-  if(namespace === name)
-    return '';
+	var namespace = name.replace(bowerRoot, '');
+	if(namespace === name)
+		return '';
 
-  return namespace;
+	return namespace;
 };
 
 // exports
 
 var loadPartials = function(ehInstance, bowerRoot, otherPaths, ignores) {
 	// Get files in bowerRoot
-  return itemsWithStats(bowerRoot)
+	return itemsWithStats(bowerRoot)
 	.then(function(items) {
-    items = classifyItems(items, otherPaths);
+		items = classifyItems(items, otherPaths);
 
-    return Promise.all(items.links
-      .map(function(link) {
-  			return realpathAsync(link)
-  			.then(function(linkedPath) {
-          return itemsWithStats(linkedPath);
-        })
-        .then(function(it) {
-          return selectValidLinkedPaths(it, ignores, link);
-        });
-      })
-    )
+		return Promise.all(items.links
+			.map(function(link) {
+				return realpathAsync(link)
+				.then(function(linkedPath) {
+					return itemsWithStats(linkedPath);
+				})
+				.then(function(it) {
+					return selectValidLinkedPaths(it, ignores, link);
+				});
+			})
+		)
 		.then(function(paths) {
 			return items.directories.concat(flatten(paths));
 		});
@@ -86,7 +86,7 @@ var loadPartials = function(ehInstance, bowerRoot, otherPaths, ignores) {
 
 			return ehInstance.getTemplates(dir.path)
 			.then(function(templates) {
-        return ({
+				return ({
 					templates: templates,
 					namespace: namespace
 				});

--- a/src/load-partials.js
+++ b/src/load-partials.js
@@ -2,43 +2,16 @@
 
 var fs = require('fs');
 var Path = require('path');
+var denodeify = require('denodeify');
 
-// async fs
+var readdirAsync = denodeify(fs.readdir);
+var lstatAsync = denodeify(fs.lstat);
+var realpathAsync = denodeify(fs.realpath);
 
 var flatten = function(list) {
   return list.reduce(function(acc, it) {
     return acc.concat(it);
   }, []);
-};
-
-var readdirAsync = function(path) {
-	return new Promise(function(res, rej) {
-		fs.readdir(path, function(err, files) {
-			if(err) return rej(err);
-
-			res(files);
-		});
-	});
-};
-
-var lstatAsync = function(path) {
-	return new Promise(function(res, rej) {
-		fs.lstat(path, function(err, stats) {
-			if(err) return rej(err);
-
-			res(stats);
-		});
-	});
-};
-
-var realpathAsync = function(path) {
-	return new Promise(function(res, rej) {
-		fs.realpath(path, function(err, path) {
-			if(err) return rej(err);
-
-			res(path);
-		});
-	});
 };
 
 var itemsWithStats = function(directory) {

--- a/src/load-partials.js
+++ b/src/load-partials.js
@@ -1,0 +1,125 @@
+"use strict";
+
+var fs = require('fs');
+var Path = require('path');
+
+// async fs
+
+var flatten = function(list) {
+  return list.reduce(function(acc, it) {
+    return acc.concat(it);
+  }, []);
+};
+
+var readdirAsync = function(path) {
+	return new Promise(function(res, rej) {
+		fs.readdir(path, function(err, files) {
+			if(err) return rej(err);
+
+			res(files);
+		});
+	});
+};
+
+var lstatAsync = function(path) {
+	return new Promise(function(res, rej) {
+		fs.lstat(path, function(err, stats) {
+			if(err) return rej(err);
+
+			res(stats);
+		});
+	});
+};
+
+var realpathAsync = function(path) {
+	return new Promise(function(res, rej) {
+		fs.realpath(path, function(err, path) {
+			if(err) return rej(err);
+
+			res(path);
+		});
+	});
+};
+
+var itemsWithStats = function(directory) {
+  return readdirAsync(directory)
+  .then(function(files) {
+    var stats = files.map(function(file) {
+      var fullPath = Path.join(directory, file);
+
+      return lstatAsync(fullPath)
+      .then(function(stat) {
+        return {name: file, path: fullPath, stat: stat};
+      });
+    });
+
+    return Promise.all(stats);
+  });
+};
+
+var classifyItems = function(items, otherPaths) {
+  return ({
+    directories: items
+      .filter(function(it) { return it.stat.isDirectory(); })
+      .concat(otherPaths)
+      .map(function(it) { return { name: it.path || it, path: it.path || it }; }),
+
+  links: items
+    .filter(function(it) { return it.stat.isSymbolicLink(); })
+    .map(function(it) { return it.path })
+  });
+};
+
+var selectValidLinkedPaths = function(linkedItems, ignores, linkPath) {
+  return linkedItems
+    .filter(function(item) { return ignores.indexOf(item.name) < 0 && item.stat.isDirectory(); })
+    .map(function(item) { return { name: Path.join(linkPath, item.name), path: item.path }; });
+};
+
+var itemNamespace = function(name, bowerRoot) {
+  var namespace = name.replace(bowerRoot, '');
+  if(namespace === name)
+    return '';
+
+  return namespace;
+};
+
+// exports
+
+var loadPartials = function(ehInstance, bowerRoot, otherPaths, ignores) {
+	// Get files in bowerRoot
+  return itemsWithStats(bowerRoot)
+	.then(function(items) {
+    items = classifyItems(items, otherPaths);
+
+    return Promise.all(items.links
+      .map(function(link) {
+  			return realpathAsync(link)
+  			.then(function(linkedPath) {
+          return itemsWithStats(linkedPath);
+        })
+        .then(function(it) {
+          return selectValidLinkedPaths(it, ignores, link);
+        });
+      })
+    )
+		.then(function(paths) {
+			return items.directories.concat(flatten(paths));
+		});
+	})
+	.then(function(directories) {
+		return Promise.all(directories.map(function(dir) {
+			var namespace = itemNamespace(dir.name, bowerRoot);
+
+			return ehInstance.getTemplates(dir.path)
+			.then(function(templates) {
+        return ({
+					templates: templates,
+					namespace: namespace
+				});
+			});
+		}));
+	});
+};
+
+module.exports = loadPartials;


### PR DESCRIPTION
Handlebars have a problem with components that have been `bower link`ed for local development, because those packages usually have a lot of extra files (`.git`, `node_modules`, etc.) and internally, handlerbars do a `glob` for `**/*.[extension]`. 

This is an attempt to cleverly ignore the parts of linked components where templates will never be, thus speeding up the loading considerably.
# To do
- [x] Supply partials paths skipping symlinks and include linked components manually
- [x] make paths resolve as they did before
- [x] refactor the crawling code and extract to a module
