### PR TITLE
Load partials from root folder of bower-linked modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules/
+/.idea/

--- a/src/load-partials.js
+++ b/src/load-partials.js
@@ -21,6 +21,7 @@ var itemsWithStats = function(directory) {
 			if (!exists) return [];
 			return readdirAsync(directory)
 				.then(function(files) {
+					files.push('.');
 					var stats = files.map(function(file) {
 						var fullPath = Path.join(directory, file);
 


### PR DESCRIPTION
Allows bower-linked modules to have partials loaded from within the module root directory (as is the case with next-welcome)
