### PR TITLE
Remove ES6 Promise now we exclusively use node 0.12 or 4.0.0 throughout

### DIFF
--- a/express.js
+++ b/express.js
@@ -1,8 +1,6 @@
 /*jshint node:true*/
 "use strict";
 
-require('es6-promise').polyfill();
-
 var Path = require('path');
 var expressHandlebars = require('express-handlebars');
 var handlebars = require('./handlebars');

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
     "handlebars": "^4.0.0"
   },
   "devDependencies": {
-    "chai": "^2.1.2",
+    "chai": "^3.3.0",
     "express": "^4.12.3",
     "mocha": "^2.0.1",
     "npm-prepublish": "^1.0.2",
     "sinon": "^1.14.1",
-    "supertest": "^0.15.0"
+    "supertest": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "dateformat": "^1.0.11",
     "denodeify": "^1.2.1",
-    "es6-promise": "^2.0.1",
     "express-handlebars": "blendlabs/express-handlebars#master",
     "handlebars": "^4.0.0"
   },


### PR DESCRIPTION
This will be a minor version
