### PR TITLE
Remove n-topic-card dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "@financial-times/n-image": "^5.0.0",
-    "@financial-times/n-topic-card": "^2.0.0",
     "dateformat": "^1.0.11",
     "denodeify": "^1.2.1",
     "express-handlebars": "^3.0.2",

--- a/src/extend-helpers.js
+++ b/src/extend-helpers.js
@@ -39,7 +39,6 @@ module.exports = function (helpers) {
 	helpers.inline = deprecate(require('./helpers/inline'));
 	helpers.buildLink = deprecate(require('./helpers/buildLink'));
 	helpers.nImagePresenter = require('@financial-times/n-image/src/handlebars-helpers/nImagePresenter');
-	helpers.concept = require('@financial-times/n-topic-card/handlebars-helpers/concept');
 
 	return helpers;
 };


### PR DESCRIPTION
So that there isn't circular dependencies. Things that need this helper
can then just add it themselves.